### PR TITLE
Adjust markup to the current DraCor schema 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ And then you automatically get a TEI/XML like this:
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title type="main">Ham</title>
+        <title>Ham</title>
         <title type="sub">A tragedy</title>
         <author>William S</author>
       </titleStmt>
@@ -196,20 +196,22 @@ And then you automatically get a TEI/XML like this:
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">
-              Licence</ref>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">
+            CC0 1.0
           </licence>
         </availability>
       </publicationStmt>
       <sourceDesc>
         <bibl type="digitalSource">
-          <name>ENTER SOURCE NAME HERE</name>
-          <idno type="URL">ENTER SOURCE URL HERE</idno>
+          <ref target="ENTER SOURCE URL HERE">
+            ENTER SOURCE NAME HERE
+          </ref>
           <availability status="free">
             <p>In the public domain.</p>
           </availability>
+        </bibl>
+        <bibl type="originalSource">
+          ENTER BIBLIOGRAPHICAL REFERENCE TO ORIGINAL SOURCE
         </bibl>
       </sourceDesc>
     </fileDesc>

--- a/parser.py
+++ b/parser.py
@@ -106,9 +106,8 @@ class Parser():
             <publisher xml:id="dracor">DraCor</publisher>
             <idno type="URL">https://dracor.org</idno>
             <availability>
-              <licence>
-                <ab>CC0 1.0</ab>
-                <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
+              <licence target="https://creativecommons.org/publicdomain/zero/1.0/">
+                CC0 1.0
               </licence>
             </availability>
           </publicationStmt>
@@ -121,11 +120,13 @@ class Parser():
         sourcedesc_as_string = """
           <sourceDesc>
             <bibl type="digitalSource">
-              <name>ENTER SOURCE NAME HERE</name>
-              <idno type="URL">ENTER SOURCE URL HERE</idno>
+              <ref target="ENTER SOURCE URL HERE">ENTER SOURCE NAME HERE</ref>
               <availability status="free">
                 <p>In the public domain.</p>
               </availability>
+            </bibl>
+            <bibl type="originalSource">
+              ENTER BIBLIOGRAPHICAL REFERENCE TO ORIGINAL SOURCE
             </bibl>
           </sourceDesc>
         """
@@ -137,7 +138,6 @@ class Parser():
     def __add_title_to_header(self, header, line):
         titlest = header.find('titleStmt')
         title = Tag(name='title')
-        title['type'] = 'main'
         title.append(line[6:].strip())
         titlest.append(title)
         

--- a/sample.xml
+++ b/sample.xml
@@ -1,8 +1,8 @@
-<TEI xml:id="insert_id" xml:lang="insert_lang" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="insert_id" xml:lang="insert_lang" type="dracor" xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title type="main">Ham</title>
+        <title>Ham</title>
         <title type="sub">A tragedy</title>
         <author>William S</author>
       </titleStmt>
@@ -10,20 +10,20 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">
-              Licence</ref>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">
+            CC0 1.0
           </licence>
         </availability>
       </publicationStmt>
       <sourceDesc>
         <bibl type="digitalSource">
-          <name>ENTER SOURCE NAME HERE</name>
-          <idno type="URL">ENTER SOURCE URL HERE</idno>
+          <ref target="ENTER SOURCE URL HERE">ENTER SOURCE NAME HERE</ref>
           <availability status="free">
             <p>In the public domain.</p>
           </availability>
+        </bibl>
+        <bibl type="originalSource">
+          ENTER BIBLIOGRAPHICAL REFERENCE TO ORIGINAL SOURCE
         </bibl>
       </sourceDesc>
     </fileDesc>

--- a/verse_sample.xml
+++ b/verse_sample.xml
@@ -1,8 +1,8 @@
-<TEI xml:id="insert_id" xml:lang="insert_lang" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="insert_id" xml:lang="insert_lang" type="dracor" xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title type="main">Damn</title>
+        <title>Damn</title>
         <title type="sub">A comedy</title>
         <author>William S</author>
       </titleStmt>
@@ -10,20 +10,20 @@
         <publisher xml:id="dracor">DraCor</publisher>
         <idno type="URL">https://dracor.org</idno>
         <availability>
-          <licence>
-            <ab>CC0 1.0</ab>
-            <ref target="https://creativecommons.org/publicdomain/zero/1.0/">
-              Licence</ref>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">
+            CC0 1.0
           </licence>
         </availability>
       </publicationStmt>
       <sourceDesc>
         <bibl type="digitalSource">
-          <name>ENTER SOURCE NAME HERE</name>
-          <idno type="URL">ENTER SOURCE URL HERE</idno>
+          <ref target="ENTER SOURCE URL HERE">ENTER SOURCE NAME HERE</ref>
           <availability status="free">
             <p>In the public domain.</p>
           </availability>
+        </bibl>
+        <bibl type="originalSource">
+          ENTER BIBLIOGRAPHICAL REFERENCE TO ORIGINAL SOURCE
         </bibl>
       </sourceDesc>
     </fileDesc>


### PR DESCRIPTION
This accommodates the sample files and the generated code to the markup recommended in the current DraCor Schema. It accommodates to changes introduced in versions [1.1.0](https://github.com/dracor-org/dracor-schema/releases/tag/1.1.0) and [1.3.0](https://github.com/dracor-org/dracor-schema/releases/tag/1.3.0).

Note, I was not able to run the code because of #4.